### PR TITLE
Add more stayman followups

### DIFF
--- a/1nt.tex
+++ b/1nt.tex
@@ -22,6 +22,8 @@ Our 1NT opening shows 14-16 HCP. 5422 hands and 5332 hands with a 5-card major a
   \item[\he4] Transfer to \spadesuit
 \end{description}
 
+\section{Stayman Sequences}
+
 \orauction{1n,2c,?}
 \begin{description}
   \item[\di2] No 4-card major
@@ -51,5 +53,21 @@ Our 1NT opening shows 14-16 HCP. 5422 hands and 5332 hands with a 5-card major a
   \item[\sp3] Minimum, 3\spadesuit. Better than pass, not enough to commit to game.
   \item[3NT] Probably a 2-card maximum that forgot to bid \cl3.
 \end{description}
+
+\orauction{1n,2c,2M,?}
+\begin{description}
+  \item[\sp2] (Over \he2). 5\spadesuit, invitational. Same followups as over 1NT-\cl2-\di2-\sp2.
+  \item[2NT] Invitiational. Promises 4 cards in OM.
+  \item[\cl3] 5+ \clubsuit ~OR 5+ \diamondsuit, GF. \di3 asks for the minor, LH. Other bids are natural, including bidding the other major to confirm a fit there.
+  \item[\di3] Artificial, confirms a fit in M, typically no shortness. Opener can bid 3M to suggest playing in M, 3NT to suggest playing there, or 4M to insist on M, denying slam interest. Other suit bids are cuebids with hands well suited for slam.
+  \item[3M] Invitational
+  \item[3OM] Unspecified splinter. Next step asks, LMH.
+  \item[3NT] To play
+  \item[\cl4] 4M, 6OM, slam try. Opener's 4OM rebid is an offer to play.
+  \item[\di4] RKC for M
+  \item[4NT] Quantitative
+\end{description}
+
+\section{Jacoby Sequences}
 
 \end{document}


### PR DESCRIPTION
I'm not sure I see the value of using 3C to show either minor and 3D to confirm a M fit.

It seems the pros are:
- More choice of game auctions
- More room to cuebid for slam auctions

And the cons are:
 - Less room for exploring when responder has a 3m bid.

It would be nice to bid some hands here.